### PR TITLE
add local dev node test action env

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,58 @@
+name: PR
+on: [pull_request]
+
+jobs:
+    lint:
+        name: Linting
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: lint
+              run: |
+                  yarn
+                  yarn lint
+              working-directory: ./
+    run_tests:
+        name: Unit Tests
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: unit_test
+              run: |
+                  yarn
+                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939211/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  ./plasm --dev & sleep 10
+                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
+                  yarn test
+              working-directory: ./
+    build_code:
+        name: Build Code
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: build
+              run: |
+                  yarn
+                  yarn build
+              working-directory: ./

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,7 +34,9 @@ jobs:
             - name: unit_test
               run: |
                   yarn
-                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip && ./plasm --dev & sleep 10
+                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  ls
+                  ./plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
               working-directory: ./

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,6 +35,7 @@ jobs:
               run: |
                   yarn
                   wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  pwd
                   ls
                   ./plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,7 +34,6 @@ jobs:
             - name: Run local dev node
               run: |
                   yarn
-                  mkdir /tmp/
                   wget -O /tmp/astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip /tmp/astar-dev-node.zip
                   pwd
                   ls

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,13 +35,10 @@ jobs:
               run: |
                   yarn
                   wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
-                  chmod +x plasm
                   ls
+                  chmod +x plasm
                   ./plasm --dev & sleep 10
-
-            - name: Run unit test
-              run: |
-                curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
+                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
               working-directory: ./
     build_code:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,10 +33,9 @@ jobs:
                   node-version: ${{ matrix.node-version }}
             - name: unit_test
               run: |
-                  yarn &&
-                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip &&
-                  ./plasm --dev & sleep 10 &&
-                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933 &&
+                  yarn
+                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip && ./plasm --dev & sleep 10
+                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
               working-directory: ./
     build_code:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,13 +31,17 @@ jobs:
               uses: actions/setup-node@v2
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: unit_test
+            - name: Run local dev node
               run: |
                   yarn
                   wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  chmod +x plasm
                   ls
                   ./plasm --dev & sleep 10
-                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
+
+            - name: Run unit test
+              run: |
+                curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
               working-directory: ./
     build_code:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -33,10 +33,10 @@ jobs:
                   node-version: ${{ matrix.node-version }}
             - name: unit_test
               run: |
-                  yarn
-                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
-                  ./plasm --dev & sleep 10
-                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
+                  yarn &&
+                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip &&
+                  ./plasm --dev & sleep 10 &&
+                  curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933 &&
                   yarn test
               working-directory: ./
     build_code:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,7 +34,7 @@ jobs:
             - name: unit_test
               run: |
                   yarn
-                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939211/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
                   ./plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,10 +34,11 @@ jobs:
             - name: Run local dev node
               run: |
                   yarn
-                  wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
+                  mkdir /tmp/
+                  wget -O /tmp/astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip /tmp/astar-dev-node.zip
                   pwd
                   ls
-                  ./plasm --dev & sleep 10
+                  /tmp/plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
     build_code:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -36,11 +36,9 @@ jobs:
                   yarn
                   wget -O astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip astar-dev-node.zip
                   ls
-                  chmod +x plasm
                   ./plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
-              working-directory: ./
     build_code:
         name: Build Code
         runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,10 +34,10 @@ jobs:
             - name: Run local dev node
               run: |
                   yarn
-                  wget -O /tmp/astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip /tmp/astar-dev-node.zip
+                  wget -O $(pwd)/astar-dev-node.zip https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip && unzip $(pwd)/astar-dev-node.zip
                   pwd
                   ls
-                  /tmp/plasm --dev & sleep 10
+                  $(pwd)/plasm --dev & sleep 10
                   curl -H "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "system_chain", "params":[]}' http://localhost:9933
                   yarn test
     build_code:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "",
   "private": true,
   "scripts": {
+    "dev": "quasar dev",
+    "build": "quasar build",
     "lint": "eslint --ext .js,.ts,.vue ./",
     "test": "echo \"No test specified\" && exit 0"
   },


### PR DESCRIPTION
Adds a test environment action. The workflow can fetch the dusty node binary, run it in local dev mode, and allow the app to access `localhost`.

Binary used:
[dusty-1.10.0-ubuntu.zip](https://github.com/PlasmNetwork/astar-apps/files/6939357/dusty-1.10.0-ubuntu.zip)
