### PR TITLE
Fix for stake when info is not present

### DIFF
--- a/src/components/store/Dapp.vue
+++ b/src/components/store/Dapp.vue
@@ -42,6 +42,7 @@ import { useApi } from 'src/hooks';
 import Avatar from 'components/common/Avatar.vue';
 import StakePanel from 'components/store/StakePanel.vue';
 import { StakingParameters, StakeInfo } from 'src/store/dapps-store/actions';
+import { endpointKey } from 'src/config/chainEndpoints';
 
 export default defineComponent({
   components: {
@@ -60,6 +61,7 @@ export default defineComponent({
     const { api } = useApi();
     const stakeInfo = ref<StakeInfo>();
     const senderAddress = computed(() => store.getters['general/selectedAccountAddress']);
+    const currentNetworkIdx = computed(() => store.getters['general/networkIdx']);
 
     const emitClickEvent = (): void => {
       emit('dappClick', props.dapp);
@@ -70,17 +72,19 @@ export default defineComponent({
     };
 
     const getDappInfo = () => {
-      store
-        .dispatch('dapps/getStakeInfo', {
-          api: api?.value,
-          senderAddress: senderAddress.value,
-          dapp: props.dapp,
-        } as StakingParameters)
-        .then((info: StakeInfo) => {
-          if (info) {
-            stakeInfo.value = info;
-          }
-        });
+      if (currentNetworkIdx.value !== endpointKey.SHIBUYA) {
+        store
+          .dispatch('dapps/getStakeInfo', {
+            api: api?.value,
+            senderAddress: senderAddress.value,
+            dapp: props.dapp,
+          } as StakingParameters)
+          .then((info: StakeInfo) => {
+            if (info) {
+              stakeInfo.value = info;
+            }
+          });
+      }
     };
 
     watch(senderAddress, () => {

--- a/src/components/store/StakePanel.vue
+++ b/src/components/store/StakePanel.vue
@@ -132,14 +132,19 @@ export default defineComponent({
     const stake = async (stakeData: StakeModel) => {
       const amount = getAmount(stakeData.amount, stakeData.unit);
       const unit = stakeData.unit;
-      const ttlStakeAmount = amount.add(props.stakeInfo?.yourStake.denomAmount);
 
-      if (ttlStakeAmount.lt(minStaking.value)) {
-        store.dispatch('general/showAlertMsg', {
-          msg: `The amount of token to be staking must greater than ${formattedMinStake.value} ${unit}`,
-          alertType: 'error',
-        });
-        return;
+      if (props.stakeInfo) {
+        const ttlStakeAmount = amount.add(props.stakeInfo?.yourStake.denomAmount);
+
+        if (ttlStakeAmount.lt(minStaking.value)) {
+          store.dispatch('general/showAlertMsg', {
+            msg: `The amount of token to be staking must greater than ${formattedMinStake.value} ${unit}`,
+            alertType: 'error',
+          });
+          return;
+        }
+      } else {
+        console.warn('No stakeInfo available. The store is unable to check some constraints.');
       }
 
       const result = await store.dispatch('dapps/stake', {

--- a/src/components/store/StakePanel.vue
+++ b/src/components/store/StakePanel.vue
@@ -51,7 +51,7 @@
     />
 
     <ClaimRewardModal
-      v-if="stakeInfo && dapp && showClaimRewardModal"
+      v-if="dapp && showClaimRewardModal"
       v-model:isOpen="showClaimRewardModal"
       :dapp="dapp"
       :stake-info="stakeInfo"
@@ -134,7 +134,7 @@ export default defineComponent({
       const unit = stakeData.unit;
 
       if (props.stakeInfo) {
-        const ttlStakeAmount = amount.add(props.stakeInfo?.yourStake.denomAmount);
+        const ttlStakeAmount = amount.add(props.stakeInfo.yourStake.denomAmount);
 
         if (ttlStakeAmount.lt(minStaking.value)) {
           store.dispatch('general/showAlertMsg', {

--- a/src/components/store/modals/ClaimRewardModal.vue
+++ b/src/components/store/modals/ClaimRewardModal.vue
@@ -2,11 +2,11 @@
   <Modal :title="`Claim reward ${dapp.name}`">
     <template #content>
       <Avatar :url="dapp.iconUrl" class="tw-w-36 tw-h-36 tw-mb-4 tw-mx-auto" />
-      <div class="tw-mt-4">
+      <div v-if="stakeInfo?.totalStake" class="tw-mt-4">
         <span class="tw-w-52 tw-inline-block">{{ $t('store.totalStake') }}</span>
         <span class="tw-font-semibold">{{ stakeInfo.totalStake }}</span>
       </div>
-      <div v-if="stakeInfo.yourStake" class="tw-mt-2">
+      <div v-if="stakeInfo?.yourStake" class="tw-mt-2">
         <span class="tw-w-52 tw-inline-block">{{ $t('store.yourStake') }}</span>
         <span class="tw-font-semibold">{{ stakeInfo.yourStake.formatted }}</span>
       </div>


### PR DESCRIPTION
**Pull Request Summary**

Currently store is unable to get stake info on Shibuya, because of large number of stakers, which caused an issue with stake function.

Closes #143 
**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- stakeInfo validation
- disable stakeinfo loading on shibuya
- enabled claim when stakeinfo is not present
![image](https://user-images.githubusercontent.com/8452361/139838455-474d9824-1a96-433d-a98a-c0512b0587dc.png)
