### PR TITLE
feat: Added CURRENT ERA field

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "tailwindcss-theme-variants": "^2.0.0-alpha.1",
     "vue-i18n": "^9.0.0-beta.0",
     "vue3-dropzone": "^0.0.7",
-    "vuejs-progress-bar": "^1.2.7",
     "vuex": "^4.0.1",
     "web3": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "stream": "^0.0.2",
     "tailwindcss-theme-variants": "^2.0.0-alpha.1",
     "vue-i18n": "^9.0.0-beta.0",
+    "vue-js-progress": "^1.0.2",
+    "vue3-autocounter": "^1.0.6",
     "vue3-dropzone": "^0.0.7",
     "vuex": "^4.0.1",
     "web3": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "tailwindcss-theme-variants": "^2.0.0-alpha.1",
     "vue-i18n": "^9.0.0-beta.0",
     "vue3-dropzone": "^0.0.7",
+    "vuejs-progress-bar": "^1.2.7",
     "vuex": "^4.0.1",
     "web3": "^1.6.0"
   },

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'vuejs-progress-bar';

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,1 +1,1 @@
-declare module 'vuejs-progress-bar';
+declare module 'vue-js-progress';

--- a/src/components/store/DiscoverDappsTab.vue
+++ b/src/components/store/DiscoverDappsTab.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <div
-      v-if="dapps.length > 0"
+      v-if="dapps.length > 0 && progress > 0"
       class="tw-flex tw-flex-wrap tw-gap-x-12 xl:tw-gap-x-18 tw-justify-center"
     >
       <TVL />
       <DappsCount />
       <Requirement />
-      <Era />
+      <Era :progress="progress" :blocks-until-next-era="blocksUntilNextEra" :era="era" />
     </div>
 
     <div class="tw-text-center tw-mb-8">
@@ -57,6 +57,7 @@ import ModalRegisterDapp from 'components/store/modals/ModalRegisterDapp.vue';
 import Dapp from 'src/components/store/Dapp.vue';
 import { formatUnitAmount } from 'src/hooks/helper/plasmUtils';
 import { useStore } from 'src/store';
+import { useCurrentEra } from 'src/hooks';
 import { DappItem } from 'src/store/dapps-store/state';
 import { computed, defineComponent, ref, watchEffect } from 'vue';
 import TVL from './statistics/TVL.vue';
@@ -80,6 +81,7 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const dapps = computed(() => store.getters['dapps/getAllDapps']);
+    const { progress, blocksUntilNextEra, era } = useCurrentEra();
 
     const maxNumberOfStakersPerContract = computed(
       () => store.getters['dapps/getMaxNumberOfStakersPerContract']
@@ -108,6 +110,9 @@ export default defineComponent({
       maxNumberOfStakersPerContract,
       minimumStakingAmount,
       showDetailsModal,
+      progress,
+      blocksUntilNextEra,
+      era,
     };
   },
 });

--- a/src/components/store/DiscoverDappsTab.vue
+++ b/src/components/store/DiscoverDappsTab.vue
@@ -7,6 +7,7 @@
       <TVL />
       <DappsCount />
       <Requirement />
+      <Era />
     </div>
 
     <div class="tw-text-center tw-mb-8">
@@ -57,10 +58,11 @@ import Dapp from 'src/components/store/Dapp.vue';
 import { formatUnitAmount } from 'src/hooks/helper/plasmUtils';
 import { useStore } from 'src/store';
 import { DappItem } from 'src/store/dapps-store/state';
-import { computed, defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref, watchEffect } from 'vue';
 import TVL from './statistics/TVL.vue';
 import DappsCount from './statistics/DappsCount.vue';
 import Requirement from './statistics/Requirement.vue';
+import Era from './statistics/Era.vue';
 
 export default defineComponent({
   components: {
@@ -73,6 +75,7 @@ export default defineComponent({
     TVL,
     DappsCount,
     Requirement,
+    Era,
   },
   setup() {
     const store = useStore();

--- a/src/components/store/statistics/DappsCount.vue
+++ b/src/components/store/statistics/DappsCount.vue
@@ -5,7 +5,6 @@
       dark:tw-bg-darkGray-800
       tw-shadow tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white
       dark:tw-text-darkGray-100
-      xl:tw-mx-2
       tw-py-4 tw-pb-8 tw-px-4
       box
     "

--- a/src/components/store/statistics/DappsCount.vue
+++ b/src/components/store/statistics/DappsCount.vue
@@ -11,7 +11,14 @@
   >
     <div class="tw-text-xl tw-font-semibold tw-mb-4">{{ $t('store.dappsCount') }}</div>
     <div class="tw-flex tw-flex-col tw-items-center">
-      <div class="tw-text-5xl tw-font-semibold">{{ dappsCount }}</div>
+      <div class="tw-text-5xl tw-font-semibold">
+        <vue3-autocounter
+          ref="counter-dapps"
+          :duration="2"
+          :end-amount="dappsCount"
+          :autoinit="dappsCount > 0"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -19,7 +26,12 @@
 <script lang="ts">
 import { useStore } from 'src/store';
 import { computed, defineComponent } from 'vue';
+import Vue3autocounter from 'vue3-autocounter';
+
 export default defineComponent({
+  components: {
+    'vue3-autocounter': Vue3autocounter,
+  },
   setup() {
     const store = useStore();
     const dapps = computed(() => store.getters['dapps/getAllDapps']);

--- a/src/components/store/statistics/Era.vue
+++ b/src/components/store/statistics/Era.vue
@@ -5,47 +5,78 @@
       dark:tw-bg-darkGray-800
       tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white
       dark:tw-text-darkGray-100
-      tw-py-4 tw-pb-4 tw-px-4
+      tw-py-4 tw-pb-2 tw-px-4
       box
     "
   >
     <div class="tw-text-xl tw-font-semibold tw-mb-2">{{ $t('store.currentEra') }}</div>
     <div class="tw-flex tw-flex-col tw-items-center tw-mb-1">
-      <div class="tw-font-bold tw-text-xl">
-        {{ era }}
+      <div class="tw-font-bold tw-text-2xl">
+        <vue3-autocounter ref="counter-era" :duration="2" :end-amount="era" :autoinit="era > 0" />
       </div>
     </div>
-    <div class="">
+    <div>
       <div class="tw-font-semibold tw-mb-1">
         {{ $t('store.blocksUntilNextEra') }}
       </div>
-      <q-linear-progress size="22px" :value="progress" color="secondary" stripe rounded>
-        <div class="absolute-full flex flex-center">
-          <q-badge
-            color="transparent"
-            text-color="white"
-            :label="blockUntilNextEra.toLocaleString('en-US')"
-          />
+      <div class="tw-relative">
+        <VueJsProgress
+          :percentage="progress"
+          bg="turquoise"
+          :delay="600"
+          :striped="true"
+          :animation="true"
+        />
+        <div class="tw-absolute tw-bottom-0 tw-w-full tw-text-white tw-font-semibold">
+          <div class="tw-flex tw-justify-center">
+            <vue3-autocounter
+              ref="counter-countdown"
+              :start-amount="startValue"
+              :end-amount="blocksUntilNextEra"
+              separator=","
+              decimal-separator="."
+              :duration="2"
+              :autoinit="blocksUntilNextEra > 0"
+              @finished="startValue = blocksUntilNextEra"
+            />
+          </div>
         </div>
-      </q-linear-progress>
+      </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import { useCurrentEra } from 'src/hooks';
+import { defineComponent, ref } from 'vue';
+import VueJsProgress from 'vue-js-progress';
+import Vue3autocounter from 'vue3-autocounter';
+import './era.scss';
 
 export default defineComponent({
+  components: {
+    VueJsProgress,
+    'vue3-autocounter': Vue3autocounter,
+  },
+  props: {
+    progress: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    era: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    blocksUntilNextEra: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+  },
   setup() {
-    const { era, blockPerEra, blockUntilNextEra, progress } = useCurrentEra();
-
-    return {
-      era,
-      blockPerEra,
-      blockUntilNextEra,
-      progress,
-    };
+    const startValue = ref<number>(0);
+    return { startValue };
   },
 });
 </script>

--- a/src/components/store/statistics/Era.vue
+++ b/src/components/store/statistics/Era.vue
@@ -1,0 +1,58 @@
+<template>
+  <div
+    class="
+      tw-bg-white
+      dark:tw-bg-darkGray-800
+      tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white
+      dark:tw-text-darkGray-100
+      tw-py-4 tw-pb-4 tw-px-4
+      box
+    "
+  >
+    <div class="tw-text-xl tw-font-semibold tw-mb-2">{{ $t('store.currentEra') }}</div>
+    <div class="tw-flex tw-flex-col tw-items-center tw-mb-1">
+      <div class="tw-font-bold tw-text-xl">
+        {{ era }}
+      </div>
+    </div>
+    <div class="">
+      <div class="tw-font-semibold tw-mb-1">
+        {{ $t('store.blocksUntilNextEra') }}
+      </div>
+      <q-linear-progress size="22px" :value="progress" color="secondary" stripe rounded>
+        <div class="absolute-full flex flex-center">
+          <q-badge
+            color="transparent"
+            text-color="white"
+            :label="blockUntilNextEra.toLocaleString('en-US')"
+          />
+        </div>
+      </q-linear-progress>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useCurrentEra } from 'src/hooks';
+
+export default defineComponent({
+  setup() {
+    const { era, blockPerEra, blockUntilNextEra, progress } = useCurrentEra();
+
+    return {
+      era,
+      blockPerEra,
+      blockUntilNextEra,
+      progress,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.box {
+  background: linear-gradient(83.83deg, #694ea4, #1b6dc1 37.5%, #1b6dc1 65.1%, #2ea0c4);
+  box-shadow: 0 2px 2px rgb(0 0 0 / 30%);
+}
+</style>

--- a/src/components/store/statistics/Requirement.vue
+++ b/src/components/store/statistics/Requirement.vue
@@ -5,7 +5,6 @@
       dark:tw-bg-darkGray-800
       tw-shadow tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white
       dark:tw-text-darkGray-100
-      xl:tw-mx-2
       tw-px-4 tw-pb-4
       box
     "

--- a/src/components/store/statistics/Requirement.vue
+++ b/src/components/store/statistics/Requirement.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="
+      lg:tw-hidden
       tw-bg-white
       dark:tw-bg-darkGray-800
       tw-shadow tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white

--- a/src/components/store/statistics/TVL.vue
+++ b/src/components/store/statistics/TVL.vue
@@ -5,7 +5,6 @@
       dark:tw-bg-darkGray-800
       tw-mb-8 tw-w-72 tw-rounded-lg tw-text-white
       dark:tw-text-darkGray-100
-      xl:tw-mx-2
       tw-py-4 tw-pb-8 tw-px-4
       box
     "

--- a/src/components/store/statistics/era.scss
+++ b/src/components/store/statistics/era.scss
@@ -1,0 +1,4 @@
+.progress {
+  height: 19px !important;
+  background-color: rgba(0,0,0,0.2) !important;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,3 +9,4 @@ export * from './useChainMetadata';
 export * from './useGetMinStaking';
 export * from './useTvl';
 export * from './useEvmDeposit';
+export * from './useCurrentEra';

--- a/src/hooks/useCurrentEra.ts
+++ b/src/hooks/useCurrentEra.ts
@@ -1,0 +1,72 @@
+import { ref, watch, onUnmounted } from 'vue';
+import { useApi } from '.';
+
+const ASTAR_BLOCK_TIME = 12000;
+
+export function useCurrentEra() {
+  const era = ref<string>('0');
+  const blockPerEra = ref<string>('0');
+  const blockUntilNextEra = ref<number>(0);
+  const progress = ref<number>(0);
+  const interval = ref<number>(0);
+  const { api } = useApi();
+
+  const getEra = async (): Promise<{ era: string; blockPerEra: string } | void> => {
+    const apiRef = api && api.value;
+    if (!apiRef) return;
+
+    const result = await Promise.all([
+      apiRef.query.dappsStaking.currentEra(),
+      apiRef.consts.dappsStaking.blockPerEra,
+      apiRef.derive.chain.bestNumber,
+    ]);
+
+    const era = result[0].toString();
+    const blockPerEra = result[1].toString();
+
+    const handleBestNumber = result[2];
+    await handleBestNumber((bestNumber) => {
+      const best = bestNumber.toNumber();
+      const progressRes = ((best % Number(blockPerEra)) / Number(blockPerEra)) * 100;
+      const countDown = Number(blockPerEra) - (best % Number(blockPerEra));
+      progress.value = progressRes * 0.01;
+      blockUntilNextEra.value = countDown;
+    });
+
+    return { era, blockPerEra };
+  };
+
+  const updateEra = async () => {
+    const data = await getEra();
+    if (!data) return;
+    era.value = data.era;
+    blockPerEra.value = data.blockPerEra;
+  };
+
+  const updateIntervalHandler = setInterval(() => {
+    interval.value = interval.value + 1;
+  }, ASTAR_BLOCK_TIME);
+
+  watch(
+    [api, interval],
+    () => {
+      const apiRef = api && api.value;
+      if (!apiRef) return;
+      apiRef.isReady.then(() => {
+        updateEra();
+      });
+    },
+    { immediate: true }
+  );
+
+  onUnmounted(() => {
+    clearInterval(updateIntervalHandler);
+  });
+
+  return {
+    era,
+    blockPerEra,
+    progress,
+    blockUntilNextEra,
+  };
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -119,6 +119,8 @@ export default {
     tvl: 'TVL IN DAPPS',
     dappsCount: 'DAPPS COUNT',
     requirement: 'REQUIREMENT',
+    currentEra: 'CURRENT ERA',
+    blocksUntilNextEra: 'Blocks until next era',
     modals: {
       alreadyClaimed: 'Already claimed:',
       contractRewards: 'Contract rewards:',

--- a/src/pages/Store.vue
+++ b/src/pages/Store.vue
@@ -5,7 +5,8 @@
         sm:tw-flex
         tw-items-end tw-border-b tw-border-gray-300
         dark:tw-border-darkGray-600
-        tw-mb-8 tw-mx-4
+        tw-mb-8
+        tw-mx--4
         sm:tw--mx-8
         tw-px-4
         sm:tw-px-8

--- a/src/pages/Store.vue
+++ b/src/pages/Store.vue
@@ -5,7 +5,7 @@
         sm:tw-flex
         tw-items-end tw-border-b tw-border-gray-300
         dark:tw-border-darkGray-600
-        tw-mb-8 tw--mx-4
+        tw-mb-8 tw-mx-4
         sm:tw--mx-8
         tw-px-4
         sm:tw-px-8
@@ -18,13 +18,34 @@
           dark:tw-text-white
           tw-mb-6
           sm:tw-mb-8
+          tw-whitespace-nowrap
         "
       >
         {{ $t('store.dappsStore') }}
       </h1>
-      <div class="tw-flex">
-        <Tab :labels="[{ label: 'Discover', path: 'discover-dapps' }]" />
-        <Tab :labels="[{ label: 'Manage', path: 'manage-dapps' }]" />
+      <div class="tw-flex tw-justify-between tw-items-center tw-w-full">
+        <div class="tw-flex">
+          <Tab :labels="[{ label: 'Discover', path: 'discover-dapps' }]" />
+          <Tab :labels="[{ label: 'Manage', path: 'manage-dapps' }]" />
+        </div>
+        <div
+          class="
+            tw-hidden
+            lg:tw-block
+            tw-hidden
+            lg:tw-block
+            2xl:tw-text-lg
+            tw-font-semibold tw-text-blue-900
+            dark:tw-text-white
+          "
+        >
+          {{
+            $t('store.warning', {
+              amount: minimumStakingAmount,
+              stakers: maxNumberOfStakersPerContract.toLocaleString('en-US'),
+            })
+          }}
+        </div>
       </div>
     </div>
     <router-view />
@@ -32,9 +53,26 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { formatUnitAmount } from 'src/hooks/helper/plasmUtils';
+import { useStore } from 'src/store';
+import { computed, defineComponent } from 'vue';
 import Tab from 'components/common/Tab.vue';
 export default defineComponent({
   components: { Tab },
+  setup() {
+    const store = useStore();
+    const maxNumberOfStakersPerContract = computed(
+      () => store.getters['dapps/getMaxNumberOfStakersPerContract']
+    );
+    const minimumStakingAmount = computed(() => {
+      const amount = store.getters['dapps/getMinimumStakingAmount'];
+      return formatUnitAmount(amount);
+    });
+
+    return {
+      maxNumberOfStakersPerContract,
+      minimumStakingAmount,
+    };
+  },
 });
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10109,6 +10109,11 @@ vue@3.2.21:
     "@vue/server-renderer" "3.2.21"
     "@vue/shared" "3.2.21"
 
+vuejs-progress-bar@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/vuejs-progress-bar/-/vuejs-progress-bar-1.2.7.tgz#40ffb8427ccde109a3b2fb038848dff433673060"
+  integrity sha512-w6lKwYT5kLSp5aCywSoBD01rZF1MeurOGX1u4gwSKCuWLZj3GB+/Trq+rI7ESesGgFYFfcg6050NyPAiCstJgw==
+
 vuex@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-4.0.2.tgz#f896dbd5bf2a0e963f00c67e9b610de749ccacc9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10066,6 +10066,11 @@ vue-i18n@^9.0.0-beta.0:
     "@intlify/vue-devtools" "9.1.7"
     "@vue/devtools-api" "^6.0.0-beta.7"
 
+vue-js-progress@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/vue-js-progress/-/vue-js-progress-1.0.2.tgz#ba737f91c9da4fea4c8f425854307523aee36aa8"
+  integrity sha512-OL2vZJR1MrQUqr0ZdGDvsaIUVaE0qdvwizxeKF82DGB9TFGA+nzdDX8PKj/r1xoVlnPtZj//YMYNxLZy8jdx0A==
+
 vue-loader@16.8.3:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.8.3.tgz#d43e675def5ba9345d6c7f05914c13d861997087"
@@ -10089,6 +10094,11 @@ vue-style-loader@4.1.3:
   dependencies:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
+
+vue3-autocounter@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vue3-autocounter/-/vue3-autocounter-1.0.6.tgz#655e275707aeb084628facd7b231be09d383521d"
+  integrity sha512-jOgCD2WaOjt/tOAAGKDm2DTyQRdKyfqJv5ElUz/vR0ZJgUd4yDd6UX6+2YU3LQpY4qoFNZkzLloAfALAqK041g==
 
 vue3-dropzone@^0.0.7:
   version "0.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10109,11 +10109,6 @@ vue@3.2.21:
     "@vue/server-renderer" "3.2.21"
     "@vue/shared" "3.2.21"
 
-vuejs-progress-bar@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/vuejs-progress-bar/-/vuejs-progress-bar-1.2.7.tgz#40ffb8427ccde109a3b2fb038848dff433673060"
-  integrity sha512-w6lKwYT5kLSp5aCywSoBD01rZF1MeurOGX1u4gwSKCuWLZj3GB+/Trq+rI7ESesGgFYFfcg6050NyPAiCstJgw==
-
 vuex@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-4.0.2.tgz#f896dbd5bf2a0e963f00c67e9b610de749ccacc9"


### PR DESCRIPTION
**Pull Request Summary**

* Added "CURRENT ERA" field in the dApps Store section
* Display the requirement information besides the tabs depending on the screen size

[Updated: 22-Nov]
* Added counter animation
https://gyazo.com/317327b2e392790ae5e52d07c3d79112

![image](https://user-images.githubusercontent.com/92044428/142732854-fe384e10-1cb0-431d-a4d6-004f32902330.png)

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

Width: 
1014px
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/92044428/142796026-bf5cf91d-1a4c-40ce-add7-c049a72a41c6.png">


1288px:
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/92044428/142796067-f4c331c8-ea1c-400a-b71e-5b30a902ff20.png">
