### PR TITLE
fix: avoid missing information panels

### DIFF
--- a/src/components/store/DiscoverDappsTab.vue
+++ b/src/components/store/DiscoverDappsTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      v-if="dapps.length > 0 && progress > 0"
+      v-if="dapps.length > 0"
       class="tw-flex tw-flex-wrap tw-gap-x-12 xl:tw-gap-x-18 tw-justify-center"
     >
       <TVL />


### PR DESCRIPTION
**Pull Request Summary**

* Show missing information panels (when the progress% of era is less than [0.5%](https://github.com/PlasmNetwork/astar-apps/blob/2270ce85680127928acb9853d8eacbee3a6b7fbc/src/hooks/useCurrentEra.ts#L30))

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes

**This pull request makes the following changes:**

**Fixes**

=Before=
Block until new era: 7,199
![Screenshot 2021-12-02 at 12 00 17 AM](https://user-images.githubusercontent.com/92044428/144271177-13f5a1b5-45ca-4f97-9eb0-4368a2d89ad2.png)
